### PR TITLE
Add disk persistence to KV store

### DIFF
--- a/src/test/java/com/springbootkvstore/lol/KVStorePersistenceTest.java
+++ b/src/test/java/com/springbootkvstore/lol/KVStorePersistenceTest.java
@@ -1,0 +1,32 @@
+package com.springbootkvstore.lol;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KVStorePersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testPersistence() {
+        Path file = tempDir.resolve("store.ser");
+        KVStore<String, String> kv = new KVStore<>(10, file.toString());
+        kv.add("a", "b");
+        kv.add("c", "d");
+
+        KVStore<String, String> kv2 = new KVStore<>(10, file.toString());
+        assertEquals("b", kv2.get("a"));
+        assertEquals("d", kv2.get("c"));
+
+        kv2.delete("a");
+
+        KVStore<String, String> kv3 = new KVStore<>(10, file.toString());
+        assertNull(kv3.get("a"));
+        assertEquals("d", kv3.get("c"));
+    }
+}


### PR DESCRIPTION
## Summary
- persist KV store data to disk with ObjectOutputStream
- load previously persisted data when store starts
- cover persistence with new unit test

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840353c17288332905a7752583a068f